### PR TITLE
fix: Trigger fullscreen on user gesture

### DIFF
--- a/TestProtocol/index.html
+++ b/TestProtocol/index.html
@@ -8,7 +8,8 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<div id="exam-container">
+    <button id="start-exam-btn">Start Exam</button>
+    <div id="exam-container" style="display: none;">
         <div id="monitoring-container">
             <video id="video-feed" autoplay muted></video>
             <div id="audio-visualizer"></div>

--- a/TestProtocol/proctoring.js
+++ b/TestProtocol/proctoring.js
@@ -82,5 +82,8 @@ document.addEventListener('keydown', (e) => {
     }
 });
 
-// Initial fullscreen enforcement
-enterFullscreen();
+document.getElementById('start-exam-btn').addEventListener('click', () => {
+    enterFullscreen();
+    document.getElementById('exam-container').style.display = 'block';
+    document.getElementById('start-exam-btn').style.display = 'none';
+});


### PR DESCRIPTION
This commit fixes an issue where the `requestFullscreen` API was being called without a user gesture, causing a permission error.

The following changes have been made:

- A "Start Exam" button has been added to `index.html`.
- The exam content is now hidden by default.
- The `requestFullscreen` API is now called when you click the "Start Exam" button.
- The exam content is shown after you click the "Start Exam" button.